### PR TITLE
Update deprecated AWS Cloud Plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The `AWS Cloud Plugin` for Elasticsearch needs to be installed on every node of 
 You can install it via the ES plugin manager:
 
 ```sh
-sudo bin/plugin install cloud-aws
+sudo bin/elasticsearch-plugin install repository-s3
 ```
 
 For more details, see the [AWS Cloud Plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/current/cloud-aws.html) instructions.


### PR DESCRIPTION
AWS Cloud Plugin has been split into two plugins. Command to install the S3 repository plugin has changed.